### PR TITLE
Supertest setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,6 @@ jobs:
       - name: Start server
         run: |
           yarn install
-          yarn start &
-          sleep 10
           yarn test
       - name: Upload coverage reports to Codecov
         env:

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Run `yarn install`
 
 ## Running
 
-Run `yarn start`. 
+Run `yarn start`.
 
 ## Testing
 
-We use Jest for testing. To run it, simply type `yarn test`. 
+We use Jest for testing. To run it, simply type `yarn test`.
 Make sure your Node's version is > v18 (`nvm install v18.15.0` to install appropriate version).

--- a/README.md
+++ b/README.md
@@ -5,3 +5,16 @@
 [![Prettier](https://github.com/poker-io/pokerio-server/actions/workflows/prettier.yml/badge.svg)](https://github.com/poker-io/pokerio-server/blob/main/.github/workflows/prettier.yml)
 [![Tests](https://github.com/poker-io/pokerio-server/actions/workflows/test.yml/badge.svg)](https://github.com/poker-io/pokerio-server/blob/main/.github/workflows/test.yml)
 [![codecov](https://codecov.io/gh/poker-io/pokerio-server/branch/main/graph/badge.svg?token=4QCZNOWFZJ)](https://codecov.io/gh/poker-io/pokerio-server)
+
+## Building
+
+Run `yarn install`
+
+## Running
+
+Run `yarn start`. 
+
+## Testing
+
+We use Jest for testing. To run it, simply type `yarn test`. 
+Make sure your Node's version is > v18 (`nvm install v18.15.0` to install appropriate version).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# pokerio-server
+
+[![Build](https://github.com/poker-io/pokerio-server/actions/workflows/main.yml/badge.svg)](https://github.com/poker-io/pokerio-server/blob/main/.github/workflows/main.yml)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # pokerio-server
 
 [![Build](https://github.com/poker-io/pokerio-server/actions/workflows/main.yml/badge.svg)](https://github.com/poker-io/pokerio-server/blob/main/.github/workflows/main.yml)
+[![Lint](https://github.com/poker-io/pokerio-server/actions/workflows/eslint.yml/badge.svg)](https://github.com/poker-io/pokerio-server/blob/main/.github/workflows/eslint.yml)
+[![Prettier](https://github.com/poker-io/pokerio-server/actions/workflows/prettier.yml/badge.svg)](https://github.com/poker-io/pokerio-server/blob/main/.github/workflows/prettier.yml)
+[![Tests](https://github.com/poker-io/pokerio-server/actions/workflows/test.yml/badge.svg)](https://github.com/poker-io/pokerio-server/blob/main/.github/workflows/test.yml)
+[![codecov](https://codecov.io/gh/poker-io/pokerio-server/branch/main/graph/badge.svg?token=4QCZNOWFZJ)](https://codecov.io/gh/poker-io/pokerio-server)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "start": "tsc && node dist/index.js",
+    "start": "tsc && node dist/server.js",
     "build": "tsc",
     "test": "jest src/tests --coverage --config package.json",
     "lint": "eslint --ext '.js,.ts,.tsx' src/",
@@ -24,21 +24,22 @@
     "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-n": "^15.0.0",
     "eslint-plugin-promise": "^6.0.0",
+    "husky": "^8.0.0",
     "prettier": "2.8.4",
+    "supertest": "^6.3.3",
     "ts-jest": "^29.0.5",
-    "typescript": "4.9.5",
-    "husky": "^8.0.0"
+    "typescript": "4.9.5"
   },
   "dependencies": {
     "express": "^4.18.2",
     "jest": "^29.5.0"
   },
-  "jest" : {
-        "collectCoverage": true,
-        "testEnvironment": "node",
-        "collectCoverageFrom": [
-                "src/*.ts"
-        ]
-
+  "jest": {
+    "collectCoverage": true,
+    "testEnvironment": "node",
+    "collectCoverageFrom": [
+      "src/*.ts"
+    ],
+    "preset": "ts-jest"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,8 @@
+import express from 'express'
+
+export const app = express()
+export const port = 42069
+
+app.get('/test', (req, res) => {
+  res.send('Hello from typescript express!')
+})

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,5 @@
+import { app, port } from './app.js'
+
+app.listen(port, () => {
+  console.log(`[server]: Server is running at localhost:${port}`)
+})

--- a/src/tests/app.test.ts
+++ b/src/tests/app.test.ts
@@ -1,0 +1,12 @@
+import { app } from '../app'
+
+import request from 'supertest'
+
+test('Simple test', (done) => {
+  request(app)
+    .get('/test')
+    .expect(200)
+    .expect('Content-Type', 'text/html; charset=utf-8')
+    .expect('Hello from typescript express!')
+    .end(done)
+})

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,6 +1,0 @@
-test('Simple test', async () => {
-  // for some reason using port from imported varaible gives weird errors
-  const response = await fetch('http://localhost:42069/test')
-  const text = await response.text()
-  expect(text).toEqual('Hello from typescript express!')
-})


### PR DESCRIPTION
Setup supertest to test http endpoints. 

Split `index.ts` to `server.ts` with `listen` and `app.ts` with endpoints. This is done, so testing of endpoints will be possible without calling `listen` (that way supertest can assign its own port, also no need to worry about closing down the server).

It turn out that imports of `ts` files need to end with `.js`, otherwise they will not work after `tsc`. See `server.ts`