### PR TITLE
Added missing build in yarn production task

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "pretty": "yarn prettier --write .",
     "pretty-check": "yarn prettier --check src/",
     "prepare": "husky install",
-    "production": "pm2 delete pokerio-server || : && pm2 start dist/index.js --name pokerio-server"
+    "production": "yarn build && pm2 delete pokerio-server || : && pm2 start dist/index.js --name pokerio-server"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",


### PR DESCRIPTION
The `yarn production` task was not building the app, which meant that it kept running the old version of the code.