### PR TITLE
Changing fcm messages order

### DIFF
--- a/src/routes/gameplay/call.ts
+++ b/src/routes/gameplay/call.ts
@@ -55,7 +55,6 @@ router.get(
       await changeCurrentPlayer(playerToken, gameId, client)
       await setPlayerState(playerToken, client, PlayerState.Called)
       await handlePlayerRaised(gameId, playerToken, maxBet, client)
-      await changeGameRoundIfNeeded(gameId, client)
 
       const message = {
         data: {
@@ -67,6 +66,7 @@ router.get(
       }
 
       await sendFirebaseMessageToEveryone(message, gameId, client)
+      await changeGameRoundIfNeeded(gameId, client)
       res.sendStatus(200)
     })
   }

--- a/src/routes/gameplay/check.ts
+++ b/src/routes/gameplay/check.ts
@@ -62,9 +62,7 @@ router.get(
       }
 
       await sendFirebaseMessageToEveryone(message, gameId, client)
-
       await changeGameRoundIfNeeded(gameId, client)
-
       return res.sendStatus(200)
     })
   }

--- a/src/routes/gameplay/fold.ts
+++ b/src/routes/gameplay/fold.ts
@@ -61,8 +61,6 @@ router.get(
         return res.sendStatus(201)
       }
 
-      await changeGameRoundIfNeeded(gameId, client)
-
       const message = {
         data: {
           player: sha256(playerToken).toString(),
@@ -73,6 +71,7 @@ router.get(
       }
 
       await sendFirebaseMessageToEveryone(message, gameId, client)
+      await changeGameRoundIfNeeded(gameId, client)
       res.sendStatus(200)
     })
   }

--- a/src/routes/gameplay/raise.ts
+++ b/src/routes/gameplay/raise.ts
@@ -59,7 +59,6 @@ router.get(
       await changeCurrentPlayer(playerToken, gameId, client)
       await handlePlayerRaised(gameId, playerToken, amount, client)
       await setPlayerState(playerToken, client, PlayerState.Raised)
-      await changeGameRoundIfNeeded(gameId, client)
 
       const message = {
         data: {
@@ -71,6 +70,7 @@ router.get(
       }
 
       await sendFirebaseMessageToEveryone(message, gameId, client)
+      await changeGameRoundIfNeeded(gameId, client)
       res.sendStatus(200)
     })
   }


### PR DESCRIPTION
In gameplay request we were inconsistent with sending new round message, some requests send action message first and then the new round message and some were doing it in reverse order. This PR fixes it